### PR TITLE
[Feat] searchActiveUsersByUsername API 개발

### DIFF
--- a/src/main/java/com/commonplant/garden/user/entity/UserRepository.java
+++ b/src/main/java/com/commonplant/garden/user/entity/UserRepository.java
@@ -4,6 +4,7 @@ import com.commonplant.garden.user.enums.Provider;
 import com.commonplant.garden.user.enums.UserStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -15,4 +16,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByProviderAndProviderId(Provider provider, String providerId);
 
     Optional<User> findByProviderAndProviderIdAndStatus(Provider provider, String providerId, UserStatus status);
+
+    List<User> findByUsernameContainingAndStatus(String username, UserStatus status);
 }

--- a/src/main/java/com/commonplant/garden/user/exception/UserErrorCode.java
+++ b/src/main/java/com/commonplant/garden/user/exception/UserErrorCode.java
@@ -11,11 +11,14 @@ public enum UserErrorCode implements ErrorCode {
 
     // entity error code
     PROVIDER_NOT_FOUND(HttpStatus.BAD_REQUEST, "U001", "지원하지 않는 소셜 로그인 Provider입니다"),
+    INVALID_SEARCH_KEYWORD(HttpStatus.BAD_REQUEST, "U002", "지원하지 않는 키워드 형식입니다."),
 
     // validation error code
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U101", "사용자를 찾을 수 없습니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "U102", "이미 사용 중인 이메일입니다."),
-    DUPLICATE_PROVIDER(HttpStatus.CONFLICT, "U103", "이미 가입된 소셜 계정입니다.")
+    DUPLICATE_PROVIDER(HttpStatus.CONFLICT, "U103", "이미 가입된 소셜 계정입니다."),
+
+
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/commonplant/garden/user/service/UserService.java
+++ b/src/main/java/com/commonplant/garden/user/service/UserService.java
@@ -3,6 +3,8 @@ package com.commonplant.garden.user.service;
 import com.commonplant.garden.user.dto.UserRequest;
 import com.commonplant.garden.user.dto.UserResponse;
 
+import java.util.List;
+
 public interface UserService {
 
     UserResponse getUserByNanoId(String nanoId);
@@ -12,4 +14,10 @@ public interface UserService {
     UserResponse updateUser(String nanoId, UserRequest.UpdateRequest request);
 
     void deleteUser(String username);
+
+    // ── helper ──────────────────────────────────────────────────────
+    UserResponse searchActiveUserByNanoId(String nanoId);
+
+    List<UserResponse> searchActiveUsersByUsername(String keyword);
+
 }

--- a/src/main/java/com/commonplant/garden/user/service/UserServiceImpl.java
+++ b/src/main/java/com/commonplant/garden/user/service/UserServiceImpl.java
@@ -12,6 +12,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -59,10 +62,35 @@ public class UserServiceImpl implements UserService {
         findActiveUserByNanoId(nanoId).deactivate();
     }
 
-    // ── helper ──────────────────────────────────────────────────────
-
+    // ── private helper ──────────────────────────────────────────────────────
+    /** Active 사용자 조회 로직 - nanoId */
     public User findActiveUserByNanoId(String nanoId) {
         return userRepository.findByNanoIdAndStatus(nanoId, UserStatus.ACTIVE)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    // ── public helper ──────────────────────────────────────────────────────
+    /** Active 사용자 조회 로직 - nanoId */
+    public UserResponse searchActiveUserByNanoId(String nanoId) {
+        User user = userRepository.findByNanoIdAndStatus(nanoId, UserStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+        return UserResponse.from(user);
+    }
+
+    /** Active 사용자 조회 로직 - username */
+    public List<UserResponse> searchActiveUsersByUsername(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            throw new BusinessException(UserErrorCode.INVALID_SEARCH_KEYWORD);
+        }
+
+        List<User> users = userRepository.findByUsernameContainingAndStatus(keyword, UserStatus.ACTIVE);
+
+        if (users.isEmpty()) {
+            throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
+        }
+
+        return users.stream()
+                .map(UserResponse::from)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
@Bjimin @sonshn 
기존 UserServiceImpl에서 호출할 수 있던 `searchActiveUserByNanoId` 메서드의 역할을 분리하기 위해 새로운 메서드를 업데이트 했습니다. 시간 되실 때 UserService의 아래의 메서드로 바꿔주시면 감사하겠습니당 :)
- `UserResponse searchActiveUserByNanoId(String nanoId);`
- `List<UserResponse> searchActiveUsersByUsername(String keyword);`